### PR TITLE
Fade other text instead of completely hiding

### DIFF
--- a/content.js
+++ b/content.js
@@ -3,8 +3,8 @@ chrome.runtime.onMessage.addListener(
     if (request.message === "clicked_browser_action" ) {
       if (! $('style[data-topicsentence-style')[0]) {
         var css = [
-              ".topicsentence-parent { visibility: hidden !important; }",
-              ".topicsentence-parent .topicsentence { visibility: visible !important; }",
+              ".topicsentence-parent { color: rgba(0,0,0,0.1) !important; }",
+              ".topicsentence-parent .topicsentence { color: rgba(0,0,0,1) !important; }",
             ].join("\n"),
             head = document.head || document.body,
             style = document.createElement('style');

--- a/content.js
+++ b/content.js
@@ -2,9 +2,11 @@ chrome.runtime.onMessage.addListener(
   function(request, sender, sendResponse) {
     if (request.message === "clicked_browser_action" ) {
       if (! $('style[data-topicsentence-style')[0]) {
+        var txtcolor = $('p').css('color').split(/\D+/);
+        var rgb = txtcolor[1] + ',' + txtcolor[2] + ',' + txtcolor[3];
         var css = [
-              ".topicsentence-parent { color: rgba(0,0,0,0.1) !important; }",
-              ".topicsentence-parent .topicsentence { color: rgba(0,0,0,1) !important; }",
+              ".topicsentence-parent, .topicsentence-parent * { color: rgba(" + rgb + ",0.2) !important; }",
+              ".topicsentence-parent .topicsentence, .topicsentence-parent .topicsentence * { color: rgba(" + rgb + ",1) !important; }",
             ].join("\n"),
             head = document.head || document.body,
             style = document.createElement('style');


### PR DESCRIPTION
However, we're hardcoding `rgba(0,0,0,?)` which won't work for sites like https://www.jwz.org/blog

<img width="1260" alt="screen shot 2016-01-08 at 9 27 28 am" src="https://cloud.githubusercontent.com/assets/473/12187825/3785c9f6-b5ea-11e5-9940-3296f758e895.png">
